### PR TITLE
Add overworld engine

### DIFF
--- a/src/game/overworld-engine.test.ts
+++ b/src/game/overworld-engine.test.ts
@@ -1,0 +1,911 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	DEFAULT_FRAME_COUNTS,
+	DEFAULT_OVERWORLD_FALLBACK_ACTION,
+	describeAction,
+	detectGamePhase,
+	extractOverworldState,
+	GamePhase,
+	getAvailableActions,
+	getFrameCount,
+	mapActionToButton,
+	type OverworldAction,
+	type OverworldState,
+	OverworldTickProcessor,
+	OverworldVoteAggregator,
+	type OverworldVoteResult,
+	overworldActionSchema,
+	parseOverworldAction,
+	UnifiedTickProcessor,
+} from './overworld-engine.js';
+
+// ─── RAM Address Constants (matching overworld-engine.ts internal addresses) ──
+
+const ADDR_IN_BATTLE = 0xd058;
+const ADDR_BATTLE_TYPE = 0xd057;
+const ADDR_TEXT_BOX_ID = 0xd125;
+const ADDR_MENU_ITEM_ID = 0xcc2d;
+const ADDR_PLAYER_X = 0xd362;
+const ADDR_PLAYER_Y = 0xd361;
+const ADDR_MAP_ID = 0xd35e;
+
+// ─── Test Helpers ────────────────────────────────────────────────────────────
+
+function makeRam(overrides?: Record<number, number>): ReadonlyArray<number> {
+	const ram = new Array(65536).fill(0) as Array<number>;
+	if (overrides) {
+		for (const [addr, val] of Object.entries(overrides)) {
+			ram[Number(addr)] = val;
+		}
+	}
+	return ram;
+}
+
+function makeOverworldState(overrides?: Partial<OverworldState>): OverworldState {
+	const now = 1000000;
+	return {
+		gameId: 'game-1',
+		turn: 0,
+		phase: GamePhase.Overworld,
+		playerX: 5,
+		playerY: 10,
+		mapId: 1,
+		availableActions: ['up', 'down', 'left', 'right', 'a_button', 'b_button', 'start', 'select'],
+		lastAction: null,
+		turnHistory: [],
+		createdAt: now,
+		updatedAt: now,
+		...overrides,
+	};
+}
+
+function makeVoteResult(overrides?: Partial<OverworldVoteResult>): OverworldVoteResult {
+	return {
+		tickId: 0,
+		gameId: 'game-1',
+		winningAction: 'up',
+		voteCounts: { up: 5 },
+		totalVotes: 5,
+		...overrides,
+	};
+}
+
+function makeMockEmulator(ram: ReadonlyArray<number> = makeRam()) {
+	return {
+		getRAM: vi.fn().mockReturnValue(ram),
+		pressButton: vi.fn(),
+		advanceFrames: vi.fn(),
+		isInitialized: true,
+		loadRom: vi.fn(),
+		readByte: vi.fn(),
+		readWord: vi.fn(),
+		readBytes: vi.fn(),
+		advanceSeconds: vi.fn(),
+		pressButtons: vi.fn(),
+		shutdown: vi.fn(),
+	};
+}
+
+function makeMockStateStore(state: OverworldState | null = makeOverworldState()) {
+	return {
+		saveState: vi.fn().mockResolvedValue(undefined),
+		loadState: vi.fn().mockResolvedValue(state),
+		publishState: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+function makeMockVoteTallier(result: OverworldVoteResult = makeVoteResult()) {
+	return {
+		tallyVotes: vi.fn().mockResolvedValue(result),
+		clearVotes: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+const mockLogger = {
+	debug: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+};
+
+// ─── mapActionToButton ───────────────────────────────────────────────────────
+
+describe('mapActionToButton', () => {
+	it('maps up to UP', () => {
+		expect(mapActionToButton('up')).toBe('UP');
+	});
+
+	it('maps down to DOWN', () => {
+		expect(mapActionToButton('down')).toBe('DOWN');
+	});
+
+	it('maps left to LEFT', () => {
+		expect(mapActionToButton('left')).toBe('LEFT');
+	});
+
+	it('maps right to RIGHT', () => {
+		expect(mapActionToButton('right')).toBe('RIGHT');
+	});
+
+	it('maps a_button to A', () => {
+		expect(mapActionToButton('a_button')).toBe('A');
+	});
+
+	it('maps b_button to B', () => {
+		expect(mapActionToButton('b_button')).toBe('B');
+	});
+
+	it('maps start to START', () => {
+		expect(mapActionToButton('start')).toBe('START');
+	});
+
+	it('maps select to SELECT', () => {
+		expect(mapActionToButton('select')).toBe('SELECT');
+	});
+});
+
+// ─── getFrameCount ───────────────────────────────────────────────────────────
+
+describe('getFrameCount', () => {
+	it('returns movement frames for directional actions', () => {
+		expect(getFrameCount('up')).toBe(DEFAULT_FRAME_COUNTS.movement);
+		expect(getFrameCount('down')).toBe(DEFAULT_FRAME_COUNTS.movement);
+		expect(getFrameCount('left')).toBe(DEFAULT_FRAME_COUNTS.movement);
+		expect(getFrameCount('right')).toBe(DEFAULT_FRAME_COUNTS.movement);
+	});
+
+	it('returns a_button frames', () => {
+		expect(getFrameCount('a_button')).toBe(DEFAULT_FRAME_COUNTS.aButton);
+	});
+
+	it('returns b_button frames', () => {
+		expect(getFrameCount('b_button')).toBe(DEFAULT_FRAME_COUNTS.bButton);
+	});
+
+	it('returns start frames', () => {
+		expect(getFrameCount('start')).toBe(DEFAULT_FRAME_COUNTS.start);
+	});
+
+	it('returns select frames', () => {
+		expect(getFrameCount('select')).toBe(DEFAULT_FRAME_COUNTS.select);
+	});
+});
+
+// ─── parseOverworldAction ────────────────────────────────────────────────────
+
+describe('parseOverworldAction', () => {
+	it('parses all valid actions', () => {
+		const validActions: Array<OverworldAction> = [
+			'up',
+			'down',
+			'left',
+			'right',
+			'a_button',
+			'b_button',
+			'start',
+			'select',
+		];
+		for (const action of validActions) {
+			expect(parseOverworldAction(action)).toBe(action);
+		}
+	});
+
+	it('returns null for invalid actions', () => {
+		expect(parseOverworldAction('fly')).toBeNull();
+		expect(parseOverworldAction('move:0')).toBeNull();
+		expect(parseOverworldAction('')).toBeNull();
+		expect(parseOverworldAction('UP')).toBeNull();
+	});
+});
+
+// ─── overworldActionSchema ───────────────────────────────────────────────────
+
+describe('overworldActionSchema', () => {
+	it('validates correct overworld actions', () => {
+		expect(overworldActionSchema.safeParse('up').success).toBe(true);
+		expect(overworldActionSchema.safeParse('a_button').success).toBe(true);
+	});
+
+	it('rejects invalid actions', () => {
+		expect(overworldActionSchema.safeParse('fly').success).toBe(false);
+		expect(overworldActionSchema.safeParse(123).success).toBe(false);
+	});
+});
+
+// ─── getAvailableActions ─────────────────────────────────────────────────────
+
+describe('getAvailableActions', () => {
+	it('returns all 8 actions for Overworld phase', () => {
+		const actions = getAvailableActions(GamePhase.Overworld);
+		expect(actions).toHaveLength(8);
+		expect(actions).toContain('up');
+		expect(actions).toContain('down');
+		expect(actions).toContain('left');
+		expect(actions).toContain('right');
+		expect(actions).toContain('a_button');
+		expect(actions).toContain('b_button');
+		expect(actions).toContain('start');
+		expect(actions).toContain('select');
+	});
+
+	it('returns directional + A/B for Menu phase', () => {
+		const actions = getAvailableActions(GamePhase.Menu);
+		expect(actions).toHaveLength(6);
+		expect(actions).toContain('up');
+		expect(actions).toContain('a_button');
+		expect(actions).toContain('b_button');
+		expect(actions).not.toContain('start');
+		expect(actions).not.toContain('select');
+	});
+
+	it('returns only A/B for Dialogue phase', () => {
+		const actions = getAvailableActions(GamePhase.Dialogue);
+		expect(actions).toHaveLength(2);
+		expect(actions).toContain('a_button');
+		expect(actions).toContain('b_button');
+	});
+
+	it('returns empty array for Battle phase', () => {
+		const actions = getAvailableActions(GamePhase.Battle);
+		expect(actions).toHaveLength(0);
+	});
+});
+
+// ─── describeAction ──────────────────────────────────────────────────────────
+
+describe('describeAction', () => {
+	it('describes directional movement in overworld', () => {
+		expect(describeAction('up', GamePhase.Overworld)).toBe('Moved up');
+		expect(describeAction('down', GamePhase.Overworld)).toBe('Moved down');
+		expect(describeAction('left', GamePhase.Overworld)).toBe('Moved left');
+		expect(describeAction('right', GamePhase.Overworld)).toBe('Moved right');
+	});
+
+	it('describes button presses in overworld', () => {
+		expect(describeAction('a_button', GamePhase.Overworld)).toBe('Pressed A (interact)');
+		expect(describeAction('b_button', GamePhase.Overworld)).toBe('Pressed B (cancel)');
+		expect(describeAction('start', GamePhase.Overworld)).toBe('Opened start menu');
+		expect(describeAction('select', GamePhase.Overworld)).toBe('Pressed Select');
+	});
+
+	it('describes dialogue-specific actions', () => {
+		expect(describeAction('a_button', GamePhase.Dialogue)).toBe('Advanced dialogue');
+		expect(describeAction('b_button', GamePhase.Dialogue)).toBe('Tried to skip dialogue');
+	});
+
+	it('describes menu-specific actions', () => {
+		expect(describeAction('a_button', GamePhase.Menu)).toBe('Confirmed menu selection');
+		expect(describeAction('b_button', GamePhase.Menu)).toBe('Cancelled/closed menu');
+		expect(describeAction('up', GamePhase.Menu)).toBe('Navigated menu up');
+		expect(describeAction('down', GamePhase.Menu)).toBe('Navigated menu down');
+	});
+});
+
+// ─── detectGamePhase ─────────────────────────────────────────────────────────
+
+describe('detectGamePhase', () => {
+	it('returns Overworld when RAM is all zeros', () => {
+		const ram = makeRam();
+		expect(detectGamePhase(ram)).toBe(GamePhase.Overworld);
+	});
+
+	it('returns Battle when in-battle flag is set', () => {
+		const ram = makeRam({ [ADDR_IN_BATTLE]: 1 });
+		expect(detectGamePhase(ram)).toBe(GamePhase.Battle);
+	});
+
+	it('returns Battle when battle type is set', () => {
+		const ram = makeRam({ [ADDR_BATTLE_TYPE]: 2 });
+		expect(detectGamePhase(ram)).toBe(GamePhase.Battle);
+	});
+
+	it('returns Dialogue when text box is active', () => {
+		const ram = makeRam({ [ADDR_TEXT_BOX_ID]: 1 });
+		expect(detectGamePhase(ram)).toBe(GamePhase.Dialogue);
+	});
+
+	it('returns Menu when menu item is active', () => {
+		const ram = makeRam({ [ADDR_MENU_ITEM_ID]: 1 });
+		expect(detectGamePhase(ram)).toBe(GamePhase.Menu);
+	});
+
+	it('prioritizes Battle over Dialogue', () => {
+		const ram = makeRam({
+			[ADDR_IN_BATTLE]: 1,
+			[ADDR_TEXT_BOX_ID]: 1,
+		});
+		expect(detectGamePhase(ram)).toBe(GamePhase.Battle);
+	});
+
+	it('prioritizes Dialogue over Menu', () => {
+		const ram = makeRam({
+			[ADDR_TEXT_BOX_ID]: 1,
+			[ADDR_MENU_ITEM_ID]: 1,
+		});
+		expect(detectGamePhase(ram)).toBe(GamePhase.Dialogue);
+	});
+});
+
+// ─── extractOverworldState ───────────────────────────────────────────────────
+
+describe('extractOverworldState', () => {
+	it('extracts player position from RAM', () => {
+		const ram = makeRam({
+			[ADDR_PLAYER_X]: 7,
+			[ADDR_PLAYER_Y]: 14,
+		});
+		const state = extractOverworldState(ram, 'game-1', 5);
+		expect(state.playerX).toBe(7);
+		expect(state.playerY).toBe(14);
+	});
+
+	it('extracts map ID from RAM', () => {
+		const ram = makeRam({ [ADDR_MAP_ID]: 42 });
+		const state = extractOverworldState(ram, 'game-1', 0);
+		expect(state.mapId).toBe(42);
+	});
+
+	it('sets game ID and turn from arguments', () => {
+		const ram = makeRam();
+		const state = extractOverworldState(ram, 'test-game', 10);
+		expect(state.gameId).toBe('test-game');
+		expect(state.turn).toBe(10);
+	});
+
+	it('detects correct phase for overworld', () => {
+		const ram = makeRam();
+		const state = extractOverworldState(ram, 'game-1', 0);
+		expect(state.phase).toBe(GamePhase.Overworld);
+		expect(state.availableActions).toHaveLength(8);
+	});
+
+	it('detects correct phase for dialogue', () => {
+		const ram = makeRam({ [ADDR_TEXT_BOX_ID]: 1 });
+		const state = extractOverworldState(ram, 'game-1', 0);
+		expect(state.phase).toBe(GamePhase.Dialogue);
+		expect(state.availableActions).toHaveLength(2);
+	});
+
+	it('initializes with null lastAction and empty turnHistory', () => {
+		const ram = makeRam();
+		const state = extractOverworldState(ram, 'game-1', 0);
+		expect(state.lastAction).toBeNull();
+		expect(state.turnHistory).toHaveLength(0);
+	});
+
+	it('sets createdAt and updatedAt timestamps', () => {
+		const ram = makeRam();
+		const before = Date.now();
+		const state = extractOverworldState(ram, 'game-1', 0);
+		const after = Date.now();
+		expect(state.createdAt).toBeGreaterThanOrEqual(before);
+		expect(state.createdAt).toBeLessThanOrEqual(after);
+		expect(state.updatedAt).toBe(state.createdAt);
+	});
+});
+
+// ─── OverworldVoteAggregator ─────────────────────────────────────────────────
+
+describe('OverworldVoteAggregator', () => {
+	function makeMockRedis() {
+		return {
+			pipeline: vi.fn().mockReturnValue({
+				zadd: vi.fn().mockReturnThis(),
+				expire: vi.fn().mockReturnThis(),
+				exec: vi.fn().mockResolvedValue([]),
+			}),
+			zrevrange: vi.fn().mockResolvedValue([]),
+			del: vi.fn().mockResolvedValue(1),
+		};
+	}
+
+	it('generates correct vote key', () => {
+		const redis = makeMockRedis();
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		const aggregator = new OverworldVoteAggregator(redis as any, mockLogger as any);
+		expect(aggregator.voteKey('game-1', 5)).toBe('overworld_votes:game-1:5');
+	});
+
+	it('records vote using Redis pipeline', async () => {
+		const redis = makeMockRedis();
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		const aggregator = new OverworldVoteAggregator(redis as any, mockLogger as any);
+
+		await aggregator.recordVote('game-1', 0, 'up');
+
+		expect(redis.pipeline).toHaveBeenCalled();
+		const pipeline = redis.pipeline();
+		expect(pipeline.zadd).toHaveBeenCalled();
+		expect(pipeline.expire).toHaveBeenCalled();
+	});
+
+	it('tallies votes and returns winning action', async () => {
+		const redis = makeMockRedis();
+		redis.zrevrange.mockResolvedValue(['up', '5', 'down', '3', 'left', '1']);
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		const aggregator = new OverworldVoteAggregator(redis as any, mockLogger as any);
+
+		const result = await aggregator.tallyVotes('game-1', 0);
+
+		expect(result.winningAction).toBe('up');
+		expect(result.totalVotes).toBe(9);
+		expect(result.voteCounts.up).toBe(5);
+		expect(result.voteCounts.down).toBe(3);
+		expect(result.voteCounts.left).toBe(1);
+	});
+
+	it('returns fallback action when no votes', async () => {
+		const redis = makeMockRedis();
+		redis.zrevrange.mockResolvedValue([]);
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		const aggregator = new OverworldVoteAggregator(redis as any, mockLogger as any);
+
+		const result = await aggregator.tallyVotes('game-1', 0);
+
+		expect(result.winningAction).toBe(DEFAULT_OVERWORLD_FALLBACK_ACTION);
+		expect(result.totalVotes).toBe(0);
+	});
+
+	it('skips invalid action members', async () => {
+		const redis = makeMockRedis();
+		redis.zrevrange.mockResolvedValue(['up', '5', 'invalid_action', '3']);
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		const aggregator = new OverworldVoteAggregator(redis as any, mockLogger as any);
+
+		const result = await aggregator.tallyVotes('game-1', 0);
+
+		expect(result.winningAction).toBe('up');
+		expect(result.totalVotes).toBe(5);
+	});
+
+	it('clears votes by deleting the key', async () => {
+		const redis = makeMockRedis();
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		const aggregator = new OverworldVoteAggregator(redis as any, mockLogger as any);
+
+		await aggregator.clearVotes('game-1', 0);
+
+		expect(redis.del).toHaveBeenCalledWith('overworld_votes:game-1:0');
+	});
+});
+
+// ─── OverworldTickProcessor ──────────────────────────────────────────────────
+
+describe('OverworldTickProcessor', () => {
+	let emulator: ReturnType<typeof makeMockEmulator>;
+	let stateStore: ReturnType<typeof makeMockStateStore>;
+	let voteTallier: ReturnType<typeof makeMockVoteTallier>;
+	let processor: OverworldTickProcessor;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		emulator = makeMockEmulator();
+		stateStore = makeMockStateStore();
+		voteTallier = makeMockVoteTallier();
+		processor = new OverworldTickProcessor(
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			emulator as any,
+			stateStore,
+			voteTallier,
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			mockLogger as any,
+			{ tickIntervalMs: 1000 },
+		);
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		processor.stop();
+		vi.useRealTimers();
+	});
+
+	describe('isRunning', () => {
+		it('returns false when not started', () => {
+			expect(processor.isRunning()).toBe(false);
+		});
+
+		it('returns true after start', async () => {
+			await processor.start('game-1');
+			expect(processor.isRunning()).toBe(true);
+		});
+
+		it('returns false after stop', async () => {
+			await processor.start('game-1');
+			processor.stop();
+			expect(processor.isRunning()).toBe(false);
+		});
+	});
+
+	describe('start', () => {
+		it('loads state from store', async () => {
+			await processor.start('game-1');
+			expect(stateStore.loadState).toHaveBeenCalledWith('game-1');
+		});
+
+		it('initializes from emulator RAM when no stored state', async () => {
+			stateStore = makeMockStateStore(null);
+			processor = new OverworldTickProcessor(
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				emulator as any,
+				stateStore,
+				voteTallier,
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				mockLogger as any,
+				{ tickIntervalMs: 1000 },
+			);
+
+			await processor.start('game-1');
+
+			expect(emulator.getRAM).toHaveBeenCalled();
+			expect(stateStore.saveState).toHaveBeenCalled();
+		});
+
+		it('throws when already running', async () => {
+			await processor.start('game-1');
+			await expect(processor.start('game-1')).rejects.toThrow('already running');
+		});
+	});
+
+	describe('getCurrentPhase', () => {
+		it('returns null when not started', () => {
+			expect(processor.getCurrentPhase()).toBeNull();
+		});
+
+		it('returns current phase after start', async () => {
+			await processor.start('game-1');
+			expect(processor.getCurrentPhase()).toBe(GamePhase.Overworld);
+		});
+	});
+
+	describe('processTick', () => {
+		it('tallies votes and presses button on emulator', async () => {
+			await processor.start('game-1');
+			vi.clearAllMocks();
+
+			await vi.advanceTimersByTimeAsync(1000);
+
+			expect(voteTallier.tallyVotes).toHaveBeenCalledWith('game-1', 0);
+			expect(emulator.pressButton).toHaveBeenCalledWith('UP');
+		});
+
+		it('advances additional frames for movement actions', async () => {
+			await processor.start('game-1');
+			vi.clearAllMocks();
+
+			await vi.advanceTimersByTimeAsync(1000);
+
+			// Movement has 6 additional frames by default
+			expect(emulator.advanceFrames).toHaveBeenCalledWith(DEFAULT_FRAME_COUNTS.movement);
+		});
+
+		it('does not advance additional frames when frame count is 0', async () => {
+			voteTallier = makeMockVoteTallier(makeVoteResult({ winningAction: 'a_button' }));
+			stateStore = makeMockStateStore(makeOverworldState());
+			processor = new OverworldTickProcessor(
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				emulator as any,
+				stateStore,
+				voteTallier,
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				mockLogger as any,
+				{ tickIntervalMs: 1000 },
+			);
+
+			await processor.start('game-1');
+			vi.clearAllMocks();
+
+			await vi.advanceTimersByTimeAsync(1000);
+
+			expect(emulator.pressButton).toHaveBeenCalledWith('A');
+			expect(emulator.advanceFrames).not.toHaveBeenCalled();
+		});
+
+		it('saves and publishes new state', async () => {
+			await processor.start('game-1');
+			vi.clearAllMocks();
+
+			await vi.advanceTimersByTimeAsync(1000);
+
+			expect(stateStore.saveState).toHaveBeenCalled();
+			expect(stateStore.publishState).toHaveBeenCalled();
+		});
+
+		it('clears votes after processing', async () => {
+			await processor.start('game-1');
+			vi.clearAllMocks();
+
+			await vi.advanceTimersByTimeAsync(1000);
+
+			expect(voteTallier.clearVotes).toHaveBeenCalledWith('game-1', 0);
+		});
+
+		it('uses fallback action when winning action is not in availableActions', async () => {
+			const state = makeOverworldState({
+				availableActions: ['a_button', 'b_button'],
+				phase: GamePhase.Dialogue,
+			});
+			stateStore = makeMockStateStore(state);
+			voteTallier = makeMockVoteTallier(makeVoteResult({ winningAction: 'up' }));
+			processor = new OverworldTickProcessor(
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				emulator as any,
+				stateStore,
+				voteTallier,
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				mockLogger as any,
+				{ tickIntervalMs: 1000 },
+			);
+
+			await processor.start('game-1');
+			vi.clearAllMocks();
+
+			await vi.advanceTimersByTimeAsync(1000);
+
+			// Fallback is 'a_button' -> 'A'
+			expect(emulator.pressButton).toHaveBeenCalledWith('A');
+		});
+
+		it('auto-stops when battle phase is detected', async () => {
+			const battleRam = makeRam({ [ADDR_IN_BATTLE]: 1 });
+			emulator = makeMockEmulator(battleRam);
+			processor = new OverworldTickProcessor(
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				emulator as any,
+				stateStore,
+				voteTallier,
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				mockLogger as any,
+				{ tickIntervalMs: 1000 },
+			);
+
+			await processor.start('game-1');
+
+			await vi.advanceTimersByTimeAsync(1000);
+
+			expect(processor.isRunning()).toBe(false);
+		});
+
+		it('appends to turn history', async () => {
+			await processor.start('game-1');
+			vi.clearAllMocks();
+
+			await vi.advanceTimersByTimeAsync(1000);
+
+			const savedState = stateStore.saveState.mock.calls[0]?.[0] as OverworldState;
+			expect(savedState.turnHistory).toHaveLength(1);
+			expect(savedState.turnHistory[0]?.action).toBe('up');
+			expect(savedState.turnHistory[0]?.turn).toBe(0);
+		});
+
+		it('increments turn number', async () => {
+			await processor.start('game-1');
+			vi.clearAllMocks();
+
+			await vi.advanceTimersByTimeAsync(1000);
+
+			const savedState = stateStore.saveState.mock.calls[0]?.[0] as OverworldState;
+			expect(savedState.turn).toBe(1);
+		});
+
+		it('uses configured frame counts when provided', async () => {
+			processor = new OverworldTickProcessor(
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				emulator as any,
+				stateStore,
+				voteTallier,
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				mockLogger as any,
+				{ tickIntervalMs: 1000, frameCounts: { movement: 20 } },
+			);
+
+			await processor.start('game-1');
+			vi.clearAllMocks();
+
+			await vi.advanceTimersByTimeAsync(1000);
+
+			expect(emulator.advanceFrames).toHaveBeenCalledWith(20);
+		});
+	});
+
+	describe('initAndStart', () => {
+		it('saves initial state and starts processor', async () => {
+			const initialState = makeOverworldState();
+
+			await processor.initAndStart('game-1', initialState);
+
+			expect(stateStore.saveState).toHaveBeenCalledWith(initialState);
+			expect(processor.isRunning()).toBe(true);
+		});
+
+		it('throws when already running', async () => {
+			await processor.start('game-1');
+			const initialState = makeOverworldState();
+			await expect(processor.initAndStart('game-1', initialState)).rejects.toThrow('already running');
+		});
+	});
+});
+
+// ─── UnifiedTickProcessor ────────────────────────────────────────────────────
+
+describe('UnifiedTickProcessor', () => {
+	let emulator: ReturnType<typeof makeMockEmulator>;
+	let mockBattleProcessor: {
+		initAndStart: ReturnType<typeof vi.fn>;
+		start: ReturnType<typeof vi.fn>;
+		stop: ReturnType<typeof vi.fn>;
+		isRunning: ReturnType<typeof vi.fn>;
+	};
+	let mockOverworldProcessor: {
+		start: ReturnType<typeof vi.fn>;
+		stop: ReturnType<typeof vi.fn>;
+		isRunning: ReturnType<typeof vi.fn>;
+	};
+	let unified: UnifiedTickProcessor;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		emulator = makeMockEmulator();
+		mockBattleProcessor = {
+			initAndStart: vi.fn().mockResolvedValue(undefined),
+			start: vi.fn().mockResolvedValue(undefined),
+			stop: vi.fn(),
+			isRunning: vi.fn().mockReturnValue(false),
+		};
+		mockOverworldProcessor = {
+			start: vi.fn().mockResolvedValue(undefined),
+			stop: vi.fn(),
+			isRunning: vi.fn().mockReturnValue(false),
+		};
+		unified = new UnifiedTickProcessor(
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			emulator as any,
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			mockBattleProcessor as any,
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			mockOverworldProcessor as any,
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			mockLogger as any,
+			{ checkIntervalMs: 500 },
+		);
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		unified.stop();
+		vi.useRealTimers();
+	});
+
+	describe('start', () => {
+		it('starts overworld processor when not in battle', async () => {
+			await unified.start('game-1');
+
+			expect(mockOverworldProcessor.start).toHaveBeenCalledWith('game-1');
+			expect(mockBattleProcessor.initAndStart).not.toHaveBeenCalled();
+		});
+
+		it('starts battle processor when in battle', async () => {
+			const battleRam = makeRam({ [ADDR_IN_BATTLE]: 1 });
+			emulator = makeMockEmulator(battleRam);
+			unified = new UnifiedTickProcessor(
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				emulator as any,
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				mockBattleProcessor as any,
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				mockOverworldProcessor as any,
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				mockLogger as any,
+				{ checkIntervalMs: 500 },
+			);
+
+			await unified.start('game-1');
+
+			expect(mockBattleProcessor.initAndStart).toHaveBeenCalled();
+			expect(mockOverworldProcessor.start).not.toHaveBeenCalled();
+		});
+
+		it('throws when already running', async () => {
+			await unified.start('game-1');
+			await expect(unified.start('game-1')).rejects.toThrow('already running');
+		});
+	});
+
+	describe('isRunning', () => {
+		it('returns false when not started', () => {
+			expect(unified.isRunning()).toBe(false);
+		});
+
+		it('returns true after start', async () => {
+			await unified.start('game-1');
+			expect(unified.isRunning()).toBe(true);
+		});
+
+		it('returns false after stop', async () => {
+			await unified.start('game-1');
+			unified.stop();
+			expect(unified.isRunning()).toBe(false);
+		});
+	});
+
+	describe('stop', () => {
+		it('stops both sub-processors', async () => {
+			await unified.start('game-1');
+
+			unified.stop();
+
+			expect(mockBattleProcessor.stop).toHaveBeenCalled();
+			expect(mockOverworldProcessor.stop).toHaveBeenCalled();
+		});
+	});
+
+	describe('getCurrentPhase', () => {
+		it('returns current phase from emulator RAM', async () => {
+			await unified.start('game-1');
+			expect(unified.getCurrentPhase()).toBe(GamePhase.Overworld);
+		});
+
+		it('returns Battle when in-battle flag set', async () => {
+			const battleRam = makeRam({ [ADDR_IN_BATTLE]: 1 });
+			emulator = makeMockEmulator(battleRam);
+			unified = new UnifiedTickProcessor(
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				emulator as any,
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				mockBattleProcessor as any,
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				mockOverworldProcessor as any,
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+				mockLogger as any,
+				{ checkIntervalMs: 500 },
+			);
+
+			await unified.start('game-1');
+			expect(unified.getCurrentPhase()).toBe(GamePhase.Battle);
+		});
+	});
+
+	describe('watchdog phase transition', () => {
+		it('restarts overworld processor when both processors stop', async () => {
+			mockOverworldProcessor.isRunning.mockReturnValue(true);
+			await unified.start('game-1');
+			vi.clearAllMocks();
+
+			// Simulate overworld processor stopping
+			mockOverworldProcessor.isRunning.mockReturnValue(false);
+			mockBattleProcessor.isRunning.mockReturnValue(false);
+
+			await vi.advanceTimersByTimeAsync(500);
+
+			expect(mockOverworldProcessor.start).toHaveBeenCalledWith('game-1');
+		});
+
+		it('starts battle processor when phase changes to battle', async () => {
+			mockOverworldProcessor.isRunning.mockReturnValue(true);
+			await unified.start('game-1');
+			vi.clearAllMocks();
+
+			// Simulate phase change to battle
+			const battleRam = makeRam({ [ADDR_IN_BATTLE]: 1 });
+			emulator.getRAM.mockReturnValue(battleRam);
+			mockOverworldProcessor.isRunning.mockReturnValue(false);
+			mockBattleProcessor.isRunning.mockReturnValue(false);
+
+			await vi.advanceTimersByTimeAsync(500);
+
+			expect(mockBattleProcessor.initAndStart).toHaveBeenCalled();
+		});
+
+		it('does not restart when a processor is still running', async () => {
+			mockOverworldProcessor.isRunning.mockReturnValue(true);
+			await unified.start('game-1');
+			vi.clearAllMocks();
+
+			// Overworld is still running
+			await vi.advanceTimersByTimeAsync(500);
+
+			expect(mockOverworldProcessor.start).not.toHaveBeenCalled();
+			expect(mockBattleProcessor.initAndStart).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/game/overworld-engine.ts
+++ b/src/game/overworld-engine.ts
@@ -1,0 +1,634 @@
+import type { Redis } from 'ioredis';
+import type { Logger } from 'pino';
+import { z } from 'zod';
+
+import type { Emulator, GbButton } from './emulator.js';
+import { extractBattleState, isInBattle } from './memory-map.js';
+import type { TickProcessor } from './tick-processor.js';
+
+// ─── Game Phase ──────────────────────────────────────────────────────────────
+
+export enum GamePhase {
+	Overworld = 'overworld',
+	Battle = 'battle',
+	Menu = 'menu',
+	Dialogue = 'dialogue',
+}
+
+// ─── Overworld Action ────────────────────────────────────────────────────────
+
+const OVERWORLD_ACTIONS = ['up', 'down', 'left', 'right', 'a_button', 'b_button', 'start', 'select'] as const;
+
+export type OverworldAction = (typeof OVERWORLD_ACTIONS)[number];
+
+export const overworldActionSchema = z.enum(OVERWORLD_ACTIONS);
+
+// ─── Overworld Turn History Entry ────────────────────────────────────────────
+
+export type OverworldTurnHistoryEntry = {
+	turn: number;
+	action: OverworldAction;
+	description: string;
+	totalVotes: number;
+};
+
+// ─── Overworld State ─────────────────────────────────────────────────────────
+
+export type OverworldState = {
+	gameId: string;
+	turn: number;
+	phase: GamePhase;
+	playerX: number;
+	playerY: number;
+	mapId: number;
+	availableActions: Array<OverworldAction>;
+	lastAction: OverworldAction | null;
+	turnHistory: Array<OverworldTurnHistoryEntry>;
+	createdAt: number;
+	updatedAt: number;
+};
+
+// ─── Overworld Vote Result ───────────────────────────────────────────────────
+
+export type OverworldVoteResult = {
+	tickId: number;
+	gameId: string;
+	winningAction: OverworldAction;
+	voteCounts: Record<string, number>;
+	totalVotes: number;
+};
+
+// ─── Overworld Tick Result ───────────────────────────────────────────────────
+
+export type OverworldTickResult = {
+	tickId: number;
+	gameId: string;
+	voteResult: OverworldVoteResult;
+	previousState: OverworldState;
+	newState: OverworldState;
+	description: string;
+};
+
+// ─── Frame Counts ────────────────────────────────────────────────────────────
+
+export type FrameCounts = {
+	movement: number;
+	aButton: number;
+	bButton: number;
+	start: number;
+	select: number;
+};
+
+// Additional frames to advance after emulator.pressButton() for animation completion.
+// pressButton() already advances ~10 frames internally.
+export const DEFAULT_FRAME_COUNTS: FrameCounts = {
+	movement: 6,
+	aButton: 0,
+	bButton: 0,
+	start: 2,
+	select: 0,
+};
+
+export const DEFAULT_OVERWORLD_FALLBACK_ACTION: OverworldAction = 'a_button';
+
+const OVERWORLD_VOTE_KEY_EXPIRY_SECONDS = 3600;
+
+// ─── Pokemon Red Overworld RAM Addresses ─────────────────────────────────────
+
+const ADDR_PLAYER_Y = 0xd361;
+const ADDR_PLAYER_X = 0xd362;
+const ADDR_MAP_ID = 0xd35e;
+const ADDR_TEXT_BOX_ID = 0xd125;
+const ADDR_MENU_ITEM_ID = 0xcc2d;
+
+// ─── Action to Button Mapping ────────────────────────────────────────────────
+
+const ACTION_BUTTON_MAP: ReadonlyMap<OverworldAction, GbButton> = new Map([
+	['up', 'UP'],
+	['down', 'DOWN'],
+	['left', 'LEFT'],
+	['right', 'RIGHT'],
+	['a_button', 'A'],
+	['b_button', 'B'],
+	['start', 'START'],
+	['select', 'SELECT'],
+]);
+
+export function mapActionToButton(action: OverworldAction): GbButton {
+	const button = ACTION_BUTTON_MAP.get(action);
+	if (!button) {
+		throw new Error(`Unknown overworld action: ${action}`);
+	}
+	return button;
+}
+
+// ─── Frame Timing ────────────────────────────────────────────────────────────
+
+export function getFrameCount(action: OverworldAction): number {
+	switch (action) {
+		case 'up':
+		case 'down':
+		case 'left':
+		case 'right':
+			return DEFAULT_FRAME_COUNTS.movement;
+		case 'a_button':
+			return DEFAULT_FRAME_COUNTS.aButton;
+		case 'b_button':
+			return DEFAULT_FRAME_COUNTS.bButton;
+		case 'start':
+			return DEFAULT_FRAME_COUNTS.start;
+		case 'select':
+			return DEFAULT_FRAME_COUNTS.select;
+	}
+}
+
+// ─── Action Parsing ──────────────────────────────────────────────────────────
+
+export function parseOverworldAction(action: string): OverworldAction | null {
+	const parsed = overworldActionSchema.safeParse(action);
+	return parsed.success ? parsed.data : null;
+}
+
+// ─── Available Actions ───────────────────────────────────────────────────────
+
+export function getAvailableActions(phase: GamePhase): Array<OverworldAction> {
+	switch (phase) {
+		case GamePhase.Overworld:
+			return ['up', 'down', 'left', 'right', 'a_button', 'b_button', 'start', 'select'];
+		case GamePhase.Menu:
+			return ['up', 'down', 'left', 'right', 'a_button', 'b_button'];
+		case GamePhase.Dialogue:
+			return ['a_button', 'b_button'];
+		case GamePhase.Battle:
+			return [];
+	}
+}
+
+// ─── Action Description ──────────────────────────────────────────────────────
+
+const DIALOGUE_DESCRIPTIONS = new Map<OverworldAction, string>([
+	['a_button', 'Advanced dialogue'],
+	['b_button', 'Tried to skip dialogue'],
+]);
+
+const MENU_DESCRIPTIONS = new Map<OverworldAction, string>([
+	['a_button', 'Confirmed menu selection'],
+	['b_button', 'Cancelled/closed menu'],
+	['up', 'Navigated menu up'],
+	['down', 'Navigated menu down'],
+	['left', 'Navigated menu left'],
+	['right', 'Navigated menu right'],
+]);
+
+const DEFAULT_DESCRIPTIONS = new Map<OverworldAction, string>([
+	['up', 'Moved up'],
+	['down', 'Moved down'],
+	['left', 'Moved left'],
+	['right', 'Moved right'],
+	['a_button', 'Pressed A (interact)'],
+	['b_button', 'Pressed B (cancel)'],
+	['start', 'Opened start menu'],
+	['select', 'Pressed Select'],
+]);
+
+export function describeAction(action: OverworldAction, phase: GamePhase): string {
+	const fallback = DEFAULT_DESCRIPTIONS.get(action) ?? 'Unknown action';
+	if (phase === GamePhase.Dialogue) {
+		return DIALOGUE_DESCRIPTIONS.get(action) ?? fallback;
+	}
+	if (phase === GamePhase.Menu) {
+		return MENU_DESCRIPTIONS.get(action) ?? fallback;
+	}
+	return fallback;
+}
+
+// ─── Game Phase Detection ────────────────────────────────────────────────────
+
+export function detectGamePhase(ram: ReadonlyArray<number>): GamePhase {
+	if (isInBattle(ram)) {
+		return GamePhase.Battle;
+	}
+
+	const textBoxId = ram[ADDR_TEXT_BOX_ID] ?? 0;
+	if (textBoxId !== 0) {
+		return GamePhase.Dialogue;
+	}
+
+	const menuItemId = ram[ADDR_MENU_ITEM_ID] ?? 0;
+	if (menuItemId !== 0) {
+		return GamePhase.Menu;
+	}
+
+	return GamePhase.Overworld;
+}
+
+// ─── Overworld State Extraction ──────────────────────────────────────────────
+
+export function extractOverworldState(ram: ReadonlyArray<number>, gameId: string, turn: number): OverworldState {
+	const phase = detectGamePhase(ram);
+	const now = Date.now();
+
+	return {
+		gameId,
+		turn,
+		phase,
+		playerX: ram[ADDR_PLAYER_X] ?? 0,
+		playerY: ram[ADDR_PLAYER_Y] ?? 0,
+		mapId: ram[ADDR_MAP_ID] ?? 0,
+		availableActions: getAvailableActions(phase),
+		lastAction: null,
+		turnHistory: [],
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+// ─── Dependency Interfaces ───────────────────────────────────────────────────
+
+export type OverworldStateStore = {
+	saveState(state: OverworldState): Promise<void>;
+	loadState(gameId: string): Promise<OverworldState | null>;
+	publishState(gameId: string, state: OverworldState): Promise<void>;
+};
+
+export type OverworldVoteTallier = {
+	tallyVotes(gameId: string, tickId: number): Promise<OverworldVoteResult>;
+	clearVotes(gameId: string, tickId: number): Promise<void>;
+};
+
+// ─── Overworld Vote Aggregator ───────────────────────────────────────────────
+
+const OVERWORLD_VOTES_KEY_PREFIX = 'overworld_votes:';
+
+export class OverworldVoteAggregator implements OverworldVoteTallier {
+	private readonly redis: Redis;
+	private readonly logger: Logger;
+
+	constructor(redis: Redis, logger: Logger) {
+		this.redis = redis;
+		this.logger = logger;
+	}
+
+	voteKey(gameId: string, tickId: number): string {
+		return `${OVERWORLD_VOTES_KEY_PREFIX}${gameId}:${tickId}`;
+	}
+
+	async recordVote(gameId: string, tickId: number, action: OverworldAction): Promise<void> {
+		const key = this.voteKey(gameId, tickId);
+		const pipeline = this.redis.pipeline();
+		pipeline.zadd(key, 'INCR', 1, action);
+		pipeline.expire(key, OVERWORLD_VOTE_KEY_EXPIRY_SECONDS);
+		await pipeline.exec();
+		this.logger.debug({ gameId, tickId, action }, 'Overworld vote recorded');
+	}
+
+	async tallyVotes(gameId: string, tickId: number): Promise<OverworldVoteResult> {
+		const key = this.voteKey(gameId, tickId);
+		const raw = await this.redis.zrevrange(key, 0, -1, 'WITHSCORES');
+
+		const voteCounts: Record<string, number> = {};
+		let totalVotes = 0;
+		let winningAction: OverworldAction = DEFAULT_OVERWORLD_FALLBACK_ACTION;
+		let highestCount = 0;
+
+		for (let i = 0; i < raw.length - 1; i += 2) {
+			const member = raw[i];
+			const scoreStr = raw[i + 1];
+			if (!(member && scoreStr)) continue;
+
+			const count = Number.parseInt(scoreStr, 10);
+			if (Number.isNaN(count)) continue;
+
+			const parsed = overworldActionSchema.safeParse(member);
+			if (!parsed.success) continue;
+
+			const action = parsed.data;
+			voteCounts[action] = count;
+			totalVotes += count;
+
+			if (count > highestCount) {
+				highestCount = count;
+				winningAction = action;
+			}
+		}
+
+		this.logger.debug({ gameId, tickId, winningAction, totalVotes }, 'Overworld votes tallied');
+		return { tickId, gameId, winningAction, voteCounts, totalVotes };
+	}
+
+	async clearVotes(gameId: string, tickId: number): Promise<void> {
+		const key = this.voteKey(gameId, tickId);
+		await this.redis.del(key);
+		this.logger.debug({ gameId, tickId }, 'Overworld votes cleared');
+	}
+}
+
+// ─── Frame Count Merge Helper ────────────────────────────────────────────────
+
+function mergeFrameCounts(custom?: Partial<FrameCounts>): FrameCounts {
+	return {
+		movement: custom?.movement ?? DEFAULT_FRAME_COUNTS.movement,
+		aButton: custom?.aButton ?? DEFAULT_FRAME_COUNTS.aButton,
+		bButton: custom?.bButton ?? DEFAULT_FRAME_COUNTS.bButton,
+		start: custom?.start ?? DEFAULT_FRAME_COUNTS.start,
+		select: custom?.select ?? DEFAULT_FRAME_COUNTS.select,
+	};
+}
+
+// ─── Overworld Tick Processor ────────────────────────────────────────────────
+
+export type OverworldTickProcessorOptions = {
+	tickIntervalMs: number;
+	frameCounts?: Partial<FrameCounts>;
+};
+
+export class OverworldTickProcessor {
+	private timer: ReturnType<typeof setInterval> | null = null;
+	private currentGameId: string | null = null;
+	private currentState: OverworldState | null = null;
+
+	private readonly emulator: Emulator;
+	private readonly stateStore: OverworldStateStore;
+	private readonly voteTallier: OverworldVoteTallier;
+	private readonly logger: Logger;
+	private readonly tickIntervalMs: number;
+	private readonly frameCounts: FrameCounts;
+
+	constructor(
+		emulator: Emulator,
+		stateStore: OverworldStateStore,
+		voteTallier: OverworldVoteTallier,
+		logger: Logger,
+		options: OverworldTickProcessorOptions,
+	) {
+		this.emulator = emulator;
+		this.stateStore = stateStore;
+		this.voteTallier = voteTallier;
+		this.logger = logger;
+		this.tickIntervalMs = options.tickIntervalMs;
+		this.frameCounts = mergeFrameCounts(options.frameCounts);
+	}
+
+	async start(gameId: string): Promise<void> {
+		if (this.timer !== null) {
+			throw new Error('OverworldTickProcessor is already running');
+		}
+
+		const state = await this.stateStore.loadState(gameId);
+		if (!state) {
+			const ram = this.emulator.getRAM();
+			this.currentState = extractOverworldState(ram, gameId, 0);
+			await this.stateStore.saveState(this.currentState);
+		} else {
+			this.currentState = state;
+		}
+
+		this.currentGameId = gameId;
+		this.startTimer(gameId);
+	}
+
+	stop(): void {
+		if (this.timer !== null) {
+			clearInterval(this.timer);
+			this.timer = null;
+		}
+		const gameId = this.currentGameId;
+		this.currentState = null;
+		this.currentGameId = null;
+		this.logger.info({ gameId }, 'Overworld tick processor stopped');
+	}
+
+	isRunning(): boolean {
+		return this.timer !== null;
+	}
+
+	getCurrentPhase(): GamePhase | null {
+		return this.currentState?.phase ?? null;
+	}
+
+	async initAndStart(gameId: string, initialState: OverworldState): Promise<void> {
+		if (this.timer !== null) {
+			throw new Error('OverworldTickProcessor is already running');
+		}
+
+		await this.stateStore.saveState(initialState);
+		this.currentState = initialState;
+		this.currentGameId = gameId;
+		this.startTimer(gameId);
+	}
+
+	private startTimer(gameId: string): void {
+		this.timer = setInterval(() => {
+			this.processTick().catch((err: unknown) => {
+				this.logger.error({ err, gameId }, 'Overworld tick processing error');
+			});
+		}, this.tickIntervalMs);
+		this.logger.info({ gameId, tickIntervalMs: this.tickIntervalMs }, 'Overworld tick processor started');
+	}
+
+	private getConfiguredFrameCount(action: OverworldAction): number {
+		switch (action) {
+			case 'up':
+			case 'down':
+			case 'left':
+			case 'right':
+				return this.frameCounts.movement;
+			case 'a_button':
+				return this.frameCounts.aButton;
+			case 'b_button':
+				return this.frameCounts.bButton;
+			case 'start':
+				return this.frameCounts.start;
+			case 'select':
+				return this.frameCounts.select;
+		}
+	}
+
+	private async processTick(): Promise<OverworldTickResult | null> {
+		const gameId = this.currentGameId;
+		const previousState = this.currentState;
+		if (!(gameId && previousState)) return null;
+
+		const currentTickId = previousState.turn;
+
+		// Tally votes
+		const voteResult = await this.voteTallier.tallyVotes(gameId, currentTickId);
+
+		// Validate winning action against available actions
+		const actionToApply = previousState.availableActions.includes(voteResult.winningAction)
+			? voteResult.winningAction
+			: DEFAULT_OVERWORLD_FALLBACK_ACTION;
+
+		// Map action to button and press on emulator
+		const button = mapActionToButton(actionToApply);
+		this.emulator.pressButton(button);
+
+		// Advance additional frames for animation completion
+		const additionalFrames = this.getConfiguredFrameCount(actionToApply);
+		if (additionalFrames > 0) {
+			this.emulator.advanceFrames(additionalFrames);
+		}
+
+		// Extract new state from emulator RAM
+		const ram = this.emulator.getRAM();
+		const description = describeAction(actionToApply, previousState.phase);
+
+		const newState: OverworldState = {
+			...extractOverworldState(ram, gameId, currentTickId + 1),
+			lastAction: actionToApply,
+			turnHistory: [
+				...previousState.turnHistory,
+				{
+					turn: currentTickId,
+					action: actionToApply,
+					description,
+					totalVotes: voteResult.totalVotes,
+				},
+			].slice(-20),
+		};
+
+		// Update current state
+		this.currentState = newState;
+
+		// Persist state
+		await this.stateStore.saveState(newState);
+
+		// Publish to WebSocket fanout
+		await this.stateStore.publishState(gameId, newState);
+
+		// Clean up processed votes
+		await this.voteTallier.clearVotes(gameId, currentTickId);
+
+		const result: OverworldTickResult = {
+			tickId: currentTickId,
+			gameId,
+			voteResult,
+			previousState,
+			newState,
+			description,
+		};
+
+		this.logger.info(
+			{
+				gameId,
+				turn: currentTickId,
+				action: actionToApply,
+				phase: newState.phase,
+				totalVotes: voteResult.totalVotes,
+				description,
+			},
+			'Overworld tick processed',
+		);
+
+		// Auto-stop when battle starts (unified processor handles transition)
+		if (newState.phase === GamePhase.Battle) {
+			this.stop();
+		}
+
+		return result;
+	}
+}
+
+// ─── Unified Tick Processor ──────────────────────────────────────────────────
+
+export type UnifiedTickProcessorOptions = {
+	checkIntervalMs: number;
+};
+
+export class UnifiedTickProcessor {
+	private watchdogTimer: ReturnType<typeof setInterval> | null = null;
+	private currentGameId: string | null = null;
+
+	private readonly emulator: Emulator;
+	private readonly battleTickProcessor: TickProcessor;
+	private readonly overworldTickProcessor: OverworldTickProcessor;
+	private readonly logger: Logger;
+	private readonly checkIntervalMs: number;
+
+	constructor(
+		emulator: Emulator,
+		battleTickProcessor: TickProcessor,
+		overworldTickProcessor: OverworldTickProcessor,
+		logger: Logger,
+		options: UnifiedTickProcessorOptions,
+	) {
+		this.emulator = emulator;
+		this.battleTickProcessor = battleTickProcessor;
+		this.overworldTickProcessor = overworldTickProcessor;
+		this.logger = logger;
+		this.checkIntervalMs = options.checkIntervalMs;
+	}
+
+	async start(gameId: string): Promise<void> {
+		if (this.watchdogTimer !== null) {
+			throw new Error('UnifiedTickProcessor is already running');
+		}
+
+		this.currentGameId = gameId;
+
+		// Detect initial phase and start appropriate processor
+		const ram = this.emulator.getRAM();
+		const phase = detectGamePhase(ram);
+
+		if (phase === GamePhase.Battle) {
+			const battleState = extractBattleState(ram, gameId, 0);
+			await this.battleTickProcessor.initAndStart(gameId, battleState);
+		} else {
+			await this.overworldTickProcessor.start(gameId);
+		}
+
+		this.logger.info({ gameId, phase }, 'Unified tick processor started');
+
+		// Start watchdog to monitor phase transitions
+		this.watchdogTimer = setInterval(() => {
+			this.checkAndRestart().catch((err: unknown) => {
+				this.logger.error({ err, gameId }, 'Phase transition check error');
+			});
+		}, this.checkIntervalMs);
+	}
+
+	stop(): void {
+		if (this.watchdogTimer !== null) {
+			clearInterval(this.watchdogTimer);
+			this.watchdogTimer = null;
+		}
+		this.battleTickProcessor.stop();
+		this.overworldTickProcessor.stop();
+		const gameId = this.currentGameId;
+		this.currentGameId = null;
+		this.logger.info({ gameId }, 'Unified tick processor stopped');
+	}
+
+	isRunning(): boolean {
+		return this.watchdogTimer !== null;
+	}
+
+	getCurrentPhase(): GamePhase {
+		const ram = this.emulator.getRAM();
+		return detectGamePhase(ram);
+	}
+
+	private async checkAndRestart(): Promise<void> {
+		const gameId = this.currentGameId;
+		if (!gameId) return;
+
+		const battleRunning = this.battleTickProcessor.isRunning();
+		const overworldRunning = this.overworldTickProcessor.isRunning();
+
+		// If a processor is still running, nothing to do
+		if (battleRunning || overworldRunning) return;
+
+		// Both processors stopped, detect current phase and restart
+		const ram = this.emulator.getRAM();
+		const phase = detectGamePhase(ram);
+
+		if (phase === GamePhase.Battle) {
+			const battleState = extractBattleState(ram, gameId, 0);
+			await this.battleTickProcessor.initAndStart(gameId, battleState);
+			this.logger.info({ gameId, phase }, 'Battle processor restarted by watchdog');
+		} else {
+			await this.overworldTickProcessor.start(gameId);
+			this.logger.info({ gameId, phase }, 'Overworld processor restarted by watchdog');
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Overworld tick processor with democracy voting and action-to-button mapping
- Game phase state machine: overworld, battle, menu, dialogue detection from RAM
- Unified tick processor that delegates to battle or overworld engine based on current phase
- OverworldVoteAggregator for Redis-backed sorted set vote tallying
- Configurable frame counts, auto-stop on battle transition, turn history tracking

## Test plan
- [x] 77 unit tests covering all public functions and classes
- [x] Tests for mapActionToButton, getFrameCount, getAvailableActions, parseOverworldAction
- [x] Tests for describeAction across all game phases
- [x] Tests for detectGamePhase with RAM state priority (battle > dialogue > menu > overworld)
- [x] Tests for extractOverworldState RAM extraction
- [x] Tests for OverworldVoteAggregator (record, tally, clear, invalid actions)
- [x] Tests for OverworldTickProcessor (start, stop, tick processing, fallback actions, battle auto-stop)
- [x] Tests for UnifiedTickProcessor (phase delegation, watchdog restarts)
- [x] Biome lint passes clean on both files